### PR TITLE
Removed call to cb in startCopy

### DIFF
--- a/lib/ncp.js
+++ b/lib/ncp.js
@@ -36,12 +36,12 @@ function ncp (source, dest, options, callback) {
     if (filter) {
       if (filter instanceof RegExp) {
         if (!filter.test(source)) {
-          return cb(true);
+          return;
         }
       }
       else if (typeof filter === 'function') {
         if (!filter(source)) {
-          return cb(true);
+          return;
         }
       }
     }


### PR DESCRIPTION
This is so filter is applied recursively, currently only applied to first path, not recursive files.