### PR TITLE
bug with path.resolve'ed win share path trailing slash

### DIFF
--- a/lib/ncp.js
+++ b/lib/ncp.js
@@ -26,6 +26,9 @@ function ncp (source, dest, options, callback) {
       finished = 0,
       running = 0,
       limit = options.limit || ncp.limit || 16;
+      
+  if (currentPath[currentPath.length - 1] == path.sep)
+	currentPath = currentPath.substr(0, currentPath.length-1);
 
   limit = (limit < 1) ? 1 : (limit > 512) ? 512 : limit;
 


### PR DESCRIPTION
path.resolve in node v10 resolves windows network path and leaves trailing slash:
\\computer\path\ should now resolve to \\computer\path