### PR TITLE
Make readdir ordering deterministic

### DIFF
--- a/lib/ncp.js
+++ b/lib/ncp.js
@@ -151,6 +151,7 @@ function ncp (source, dest, options, callback) {
       if (err) {
         return onError(err);
       }
+      items.sort();
       items.forEach(function (item) {
         startCopy(dir + '/' + item);
       });


### PR DESCRIPTION
The .sort is extremely fast, and it cannot hurt to make things
deterministic, to avoid flickering tests for instance.